### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ recyclerView.addItemDecoration(GridMarginDecoration(
 ```kotlin
 recyclerView.addItemDecoration(GridSpanMarginDecoration(
     margin = resources.dpToPx(8),
-    gridLayoutManager = gridLayoutManager,
-    orientation = RecyclerView.VERTICAL
+    gridLayoutManager = gridLayoutManager
 ))
 ```
 


### PR DESCRIPTION
`GridSpanMarginDecoration` doesn't expect an `orientation` parameter.